### PR TITLE
Use Explicit TaskARN for determining region rather than cluster

### DIFF
--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -53,7 +53,7 @@ func (c *ECSFargateCollector) parseMetadata(meta *v2.Task, parseAll bool) ([]*Ta
 			tags.AddLow("ecs_cluster_name", clusterName)
 
 			// aws region from cluster arn
-			region := parseFargateRegion(meta.ClusterName)
+			region := parseFargateRegion(meta.TaskARN)
 			if region != "" {
 				tags.AddLow("region", region)
 			}


### PR DESCRIPTION
### What does this PR do?

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html#task-metadata-endpoint-v2-response

Cluster means "The Amazon Resource Name (ARN) or short name of the Amazon ECS cluster to which the task belongs."

Rather than the ambiguity, use the explicit task arn to make sure it gets parsed correctly

### Motivation

ECS Fargate setups do not properly parse the `region` tag for trace metrics

### Additional Notes

This is a best guess

### Describe your test plan

If you guys can help this get built and into dockerhub, I can build it on our side and use it in ECS to see that it works as desired.
